### PR TITLE
Remove support for attribute macros

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -234,3 +234,4 @@ lib/xercesImpl.jar
 lib/xml-apis.jar
 lib/xsd/xmlparser/nokogiri.rb
 patches/libxml2/0001-Revert-Do-not-URI-escape-in-server-side-includes.patch
+patches/libxml2/0002-Remove-script-macro-support.patch

--- a/patches/libxml2/0002-Remove-script-macro-support.patch
+++ b/patches/libxml2/0002-Remove-script-macro-support.patch
@@ -1,0 +1,40 @@
+From 27e4aa8d885e47a296ea78d114dbbe8fc7aa3508 Mon Sep 17 00:00:00 2001
+From: Kevin Solorio <soloriok@gmail.com>
+Date: Fri, 1 Feb 2019 14:32:42 -0800
+Subject: [PATCH] Revert-support-html-h-b-7-1
+
+---
+ entities.c | 17 -----------------
+ 1 file changed, 17 deletions(-)
+
+diff --git a/entities.c b/entities.c
+index 43549bc5..82652f6d 100644
+--- a/entities.c
++++ b/entities.c
+@@ -623,23 +623,6 @@ xmlEncodeEntitiesInternal(xmlDocPtr doc, const xmlChar *input, int attr) {
+ 	    *out++ = 't';
+ 	    *out++ = ';';
+ 	} else if (*cur == '&') {
+-	    /*
+-	     * Special handling of &{...} construct from HTML 4, see
+-	     * http://www.w3.org/TR/html401/appendix/notes.html#h-B.7.1
+-	     */
+-	    if (html && attr && (cur[1] == '{') &&
+-	        (strchr((const char *) cur, '}'))) {
+-	        while (*cur != '}') {
+-		    *out++ = *cur++;
+-		    indx = out - buffer;
+-		    if (indx + 100 > buffer_size) {
+-			growBufferReentrant();
+-			out = &buffer[indx];
+-		    }
+-		}
+-		*out++ = *cur++;
+-		continue;
+-	    }
+ 	    *out++ = '&';
+ 	    *out++ = 'a';
+ 	    *out++ = 'm';
+-- 
+2.16.2
+

--- a/test/html/test_attributes_do_not_support_macros.rb
+++ b/test/html/test_attributes_do_not_support_macros.rb
@@ -1,0 +1,15 @@
+require "helper"
+
+module Nokogiri
+  module HTML
+    class TestAttributesDoNotSupportMacros < Nokogiri::TestCase
+      def test_attribute_macros_are_escaped
+        html = "<p><i for=\"&{<test>}\"></i></p>"
+        document = Nokogiri::HTML::Document.new
+        nodes = document.parse(html)
+
+        assert_equal "<p><i for=\"&amp;{&lt;test&gt;}\"></i></p>", nodes[0].to_s
+      end
+    end
+  end
+end


### PR DESCRIPTION
libxml2 added support for future script macros

https://www.w3.org/TR/html401/appendix/notes.html#h-B.7.1

Usage of the macros do not seem widely adopted and the usage of
script macros are still not clearly defined.

