### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Nokogiri Changelog
 
-## unreleased
+## 1.10.2 / 2019-03-12
 
 ### Security
 

--- a/lib/nokogiri/version.rb
+++ b/lib/nokogiri/version.rb
@@ -1,6 +1,6 @@
 module Nokogiri
   # The version of Nokogiri you are using
-  VERSION = '1.10.1'
+  VERSION = '1.10.2'
 
   class VersionInfo # :nodoc:
     def jruby?


### PR DESCRIPTION
preparing to bump version of nokogiri from 1.10.1 - 1.10.2
* updated changelog with a date
* updated lib/nokogiri/version.rb with new version info



